### PR TITLE
Replace URLs with environment placeholders

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,11 +15,18 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
+      WHATSAPP: ${{ secrets.WHATSAPP }}
     steps:
-    - uses: actions/checkout@v4
-    #  ↓ espera blog-builder terminar (se existir outro job)
-    - uses: christopher-dg/wait-on-check-action@v1
-      with:
-        token: ${{ github.token }}
-        checkName: build    # nome do job gerador de artefato
-    - uses: actions/deploy-pages@v4
+      - uses: actions/checkout@v4
+      #  ↓ espera blog-builder terminar (se existir outro job)
+      - uses: christopher-dg/wait-on-check-action@v1
+        with:
+          token: ${{ github.token }}
+          checkName: build    # nome do job gerador de artefato
+      - name: Replace tokens
+        run: |
+          find . -name '*.html' -exec sed -i "s|{{WEBHOOK_URL}}|${WEBHOOK_URL}|g" {} +
+          find . -name '*.html' -exec sed -i "s|{{WHATSAPP}}|${WHATSAPP}|g" {} +
+      - uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ A publicação acontece via GitHub Pages através da workflow [`deploy.yml`](./.
 
 Para pré‑visualizar localmente, clone o projeto e abra qualquer arquivo HTML do diretório em seu navegador. Não há passos de build manual, pois todo processamento é feito pelas ações do GitHub.
 
+### Variáveis de ambiente
+
+A action de deploy substitui tokens nos HTML usando dois segredos configurados no repositório:
+
+- `WEBHOOK_URL` – URL para onde os formulários são enviados.
+- `WHATSAPP` – número usado nos links do WhatsApp (apenas dígitos, exemplo `5541999999999`).
+
+Se for fazer deploy manualmente ou pré‑visualizar o site com as URLs reais, defina essas variáveis e substitua os tokens `{{WEBHOOK_URL}}` e `{{WHATSAPP}}` antes de publicar.
+
 ## Testes
 
 No momento não existem testes automatizados. Quando forem adicionados, configure o ambiente instalando as dependências indicadas (por exemplo, `npm install` ou `pip install -r requirements.txt`) e execute a ferramenta de testes definida pelo projeto. Atualize este README conforme necessário.

--- a/blog/2025-05-20-como-o-parcelamento-impacta-diretamente-seu-fluxo-de-caixa.html
+++ b/blog/2025-05-20-como-o-parcelamento-impacta-diretamente-seu-fluxo-de-caixa.html
@@ -48,7 +48,7 @@
       <a href="/blog/">Blog</a>
       <a href="/pf.html">Diagnóstico PF</a>
       <a href="/pj.html">Diagnóstico PJ</a>
-      <a class="cta" href="https://wa.me/5541991937663">WhatsApp</a>
+      <a class="cta" href="https://wa.me/{{WHATSAPP}}">WhatsApp</a>
   </header>
 
   <!-- CONTEÚDO -->

--- a/empresas.html
+++ b/empresas.html
@@ -84,8 +84,8 @@
 
   <script>
     /* CONFIG */
-    const NUM_WPP = '5541991937663';
-    const WEBHOOK = 'https://primary-production-a61c.up.railway.app/webhook-test/git-hub';
+    const NUM_WPP = '{{WHATSAPP}}';
+    const WEBHOOK = '{{WEBHOOK_URL}}';
     const ORIGEM  = 'Landing PJ';
 
     async function enviaLead(payload){

--- a/partials/header.html
+++ b/partials/header.html
@@ -24,7 +24,7 @@
   <a href="/blog/">Blog</a>
   <div class="topnav__spacer"></div>
 
-  <a class="topnav__cta" href="https://wa.me/5541991937663" target="_blank">
+  <a class="topnav__cta" href="https://wa.me/{{WHATSAPP}}" target="_blank">
     <svg fill="none" viewBox="0 0 24 24"><path stroke-width="2" d="M5 12h14M13 5l7 7-7 7"/></svg>
     Fale com um especialista
   </a>

--- a/partials/template-post.html
+++ b/partials/template-post.html
@@ -48,7 +48,7 @@
       <a href="/blog/">Blog</a>
       <a href="/pf.html">Diagnóstico PF</a>
       <a href="/pj.html">Diagnóstico PJ</a>
-      <a class="cta" href="https://wa.me/5541991937663">WhatsApp</a>
+      <a class="cta" href="https://wa.me/{{WHATSAPP}}">WhatsApp</a>
   </header>
 
   <!-- CONTEÚDO -->

--- a/pessoa-fisica.html
+++ b/pessoa-fisica.html
@@ -104,8 +104,8 @@
         </script>
 <script>
     /* CONFIG */
-    const numeroWpp = '5541991937663';
-    const WEBHOOK   = 'https://primary-production-a61c.up.railway.app/webhook-test/git-hub';
+    const numeroWpp = '{{WHATSAPP}}';
+    const WEBHOOK   = '{{WEBHOOK_URL}}';
     const ORIGEM    = 'Landing PF';
     
     /* ENVIA PRO N8N */


### PR DESCRIPTION
## Summary
- replace webhook and WhatsApp values in HTML by tokens
- inject real values in `deploy.yml`
- document `WEBHOOK_URL` and `WHATSAPP` secrets

## Testing
- `git diff --cached --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840833a724c832d831b485437bb53dd