### PR TITLE
Fix formStatus message literals

### DIFF
--- a/pessoafisica-teste.html
+++ b/pessoafisica-teste.html
@@ -1230,7 +1230,7 @@
 
                 if (webhookUrl === 'SUA_URL_DO_WEBHOOK_AQUI' || webhookUrl === '') {
                     console.error('URL do Webhook não definida.');
-                    if(formStatus) formStatus.innerHTML = <p style="color: #ff6b6b;">Erro de configuração do servidor. Tente mais tarde.</p>;
+                    if(formStatus) formStatus.innerHTML = '<p style="color: #ff6b6b;">Erro de configuração do servidor. Tente mais tarde.</p>';
                     return;
                 }
                 
@@ -1261,7 +1261,7 @@
                 .then(data => {
                     console.log('Sucesso:', data);
                     form.reset(); 
-                    if(formStatus) formStatus.innerHTML = <p style="color: var(--accent);">Obrigado! Sua mensagem foi enviada com sucesso. Entraremos em contato em breve.</p>;
+                    if(formStatus) formStatus.innerHTML = '<p style="color: var(--accent);">Obrigado! Sua mensagem foi enviada com sucesso. Entraremos em contato em breve.</p>';
                     submitButton.innerHTML = 'Enviado!';
                     setTimeout(() => {
                         submitButton.disabled = false;
@@ -1271,7 +1271,7 @@
                 })
                 .catch((error) => {
                     console.error('Erro:', error);
-                    if(formStatus) formStatus.innerHTML = <p style="color: #ff6b6b;">Desculpe, ocorreu um erro ao enviar sua mensagem. Por favor, tente novamente mais tarde.</p>;
+                    if(formStatus) formStatus.innerHTML = '<p style="color: #ff6b6b;">Desculpe, ocorreu um erro ao enviar sua mensagem. Por favor, tente novamente mais tarde.</p>';
                     submitButton.disabled = false;
                     submitButton.innerHTML = originalButtonHTML;
                 });


### PR DESCRIPTION
## Summary
- fix string literals when showing form status messages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855753f1358832da9b1d79b48fee1a0